### PR TITLE
Add system::loadavg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,12 @@
 extern crate lazy_static;
 extern crate libc;
 
+#[macro_use]
+mod utils;
+
 pub mod pidfile;
 pub mod process;
 pub mod system;
-mod utils;
-
 /// Type for process identifiers.
 ///
 /// This should expand to `i32` (signed 32 bit integer).

--- a/src/process.rs
+++ b/src/process.rs
@@ -371,19 +371,6 @@ pub struct Process {
     pub exit_code: i32,
 }
 
-macro_rules! try_parse {
-    ($field:expr) => {
-        try_parse!($field, FromStr::from_str)
-    };
-    ($field:expr, $from_str:path) => {
-        try!(match $from_str($field) {
-            Ok(result) => Ok(result),
-            Err(_) => Err(Error::new(ErrorKind::InvalidInput,
-                format!("Could not parse {:?}", $field)))
-        })
-    };
-}
-
 impl Process {
     /// Attempts to read process information from `/proc/[pid]/stat`.
     ///

--- a/src/system.rs
+++ b/src/system.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 
 use std::io::{Result, ErrorKind, Error};
 
+use PID;
+
 use utils::read_file;
 
 #[derive(Debug)]
@@ -105,6 +107,47 @@ impl SwapMemory {
     }
 }
 
+#[derive(Debug)]
+pub struct LoadAverage {
+    /// number of jobs in the run queue averaged over 1 minute
+    pub one: f32,
+
+    /// number of jobs in the run queue averaged over 5 minute
+    pub five: f32,
+
+    /// number of jobs in the run queue averaged over 15 minute
+    pub fifteen: f32,
+
+    /// current number of runnable kernel entities
+    pub runnable: i32,
+
+    /// total number of runnable kernel entities
+    pub total_runnable: i32,
+
+    /// pid for the most recently created process
+    pub last_pid: PID,
+}
+
+impl LoadAverage {
+    fn new(
+        one: f32,
+        five: f32,
+        fifteen: f32,
+        runnable: i32,
+        total_runnable: i32,
+        last_pid: PID,
+    ) -> LoadAverage {
+        LoadAverage {
+            one,
+            five,
+            fifteen,
+            runnable,
+            total_runnable,
+            last_pid,
+        }
+    }
+}
+
 /// Returns the system uptime in seconds.
 ///
 /// `/proc/uptime` contains the system uptime and idle time.
@@ -120,6 +163,33 @@ fn uptime_internal(data: &str) -> isize {
     let numbers: Vec<&str> = data.split(' ').collect();
     let uptime: Vec<&str> = numbers[0].split('.').collect();
     FromStr::from_str(uptime[0]).unwrap()
+}
+
+/// Returns the system load average
+///
+/// `/proc/loadavg` contains the system load average
+pub fn loadavg() -> Result<LoadAverage> {
+    let data = read_file(Path::new("/proc/loadavg"))?;
+    // strips off any trailing new line as well
+    let fields: Vec<&str> = data.split_whitespace().collect();
+
+    let one = try_parse!(fields[0]);
+    let five = try_parse!(fields[1]);
+    let fifteen = try_parse!(fields[2]);
+    let last_pid = try_parse!(fields[4]);
+
+    let entities = fields[3].split('/').collect::<Vec<&str>>();
+    let runnable = try_parse!(entities[0]);
+    let total_runnable = try_parse!(entities[1]);
+
+    Ok(LoadAverage::new(
+        one,
+        five,
+        fifteen,
+        runnable,
+        total_runnable,
+        last_pid,
+    ))
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,3 +10,16 @@ pub fn read_file(path: &Path) -> Result<String> {
     try!(file.read_to_string(&mut buffer));
     Ok(buffer)
 }
+
+macro_rules! try_parse {
+    ($field:expr) => {
+        try_parse!($field, FromStr::from_str)
+    };
+    ($field:expr, $from_str:path) => {
+        try!(match $from_str($field) {
+            Ok(result) => Ok(result),
+            Err(_) => Err(Error::new(ErrorKind::InvalidInput,
+                format!("Could not parse {:?}", $field)))
+        })
+    };
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -23,3 +23,12 @@ fn swap_memory() {
         assert!(sm.percent >= 0.0);
     }
 }
+
+#[test]
+fn loadaverage() {
+    let load = psutil::system::loadavg().unwrap();
+    // shouldn't be negative
+    assert!(load.one >= 0.0);
+    assert!(load.five >= 0.0);
+    assert!(load.fifteen >= 0.0);
+}


### PR DESCRIPTION
Add function to return the system's load average. This includes the
average number of runnable entities averaged over one, five, and fifteen
minutes as well as statistics on the total number of runnable entities
and the last pid that was used.

Behind the scenes, the `try_parse` macro was moved to utils since it's
now used in multiple places.