### PR TITLE
Automatically update docs with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: rust
 sudo: false
 
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo doc --verbose
+
 deploy:
   provider: pages
   skip-cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: rust
 sudo: false
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep-history: true
+  local-dir: target/doc/psutil
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: target/doc/psutil
+  local-dir: target/doc/
   on:
     branch: master


### PR DESCRIPTION
http://borntyping.github.io/rust-psutil/psutil/ is a bit out of date - this should mean Travis CI auto-updates it, per https://docs.travis-ci.com/user/deployment/pages/.