### PR TITLE
Clippy

### DIFF
--- a/examples/kill.rs
+++ b/examples/kill.rs
@@ -2,8 +2,8 @@
 
 extern crate psutil;
 
-use std::path::Path;
 use psutil::process::Process;
+use std::path::Path;
 
 #[cfg(not(test))]
 fn main() {

--- a/examples/ps.rs
+++ b/examples/ps.rs
@@ -4,12 +4,19 @@ extern crate psutil;
 
 #[cfg(not(test))]
 fn main() {
-    println!("{:>5} {:^5} {:>8} {:>8} {:.100}",
-        "PID", "STATE", "UTIME", "STIME", "CMD");
+    println!(
+        "{:>5} {:^5} {:>8} {:>8} {:.100}",
+        "PID", "STATE", "UTIME", "STIME", "CMD"
+    );
 
     for p in &psutil::process::all().unwrap() {
-        println!("{:>5} {:^5} {:>8.2} {:>8.2} {:.100}",
-            p.pid, p.state.to_string(), p.utime, p.stime,
-            p.cmdline().unwrap().unwrap_or(format!("[{}]", p.comm)));
+        println!(
+            "{:>5} {:^5} {:>8.2} {:>8.2} {:.100}",
+            p.pid,
+            p.state.to_string(),
+            p.utime,
+            p.stime,
+            p.cmdline().unwrap().unwrap_or(format!("[{}]", p.comm))
+        );
     }
 }

--- a/src/pidfile.rs
+++ b/src/pidfile.rs
@@ -1,8 +1,8 @@
 //! Contains functions to read and write pidfiles.
 
 use std::fs::File;
-use std::io::{Read, Write};
 use std::io::{Error, ErrorKind, Result};
+use std::io::{Read, Write};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -19,8 +19,9 @@ pub fn read_pidfile(path: &Path) -> Result<super::PID> {
 
     match FromStr::from_str(&contents) {
         Ok(pid) => Ok(pid),
-        Err(_) => {
-            Err(Error::new(ErrorKind::Other, "Could not parse pidfile as PID"))
-        }
+        Err(_) => Err(Error::new(
+            ErrorKind::Other,
+            "Could not parse pidfile as PID",
+        )),
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -524,7 +524,7 @@ impl Process {
     fn environ_internal(file_contents: &str) -> Result<HashMap<String, String>> {
         let mut ret = HashMap::new();
         for s in file_contents.split_terminator('\0') {
-            let vv: Vec<&str> = s.splitn(2, "=").collect();
+            let vv: Vec<&str> = s.splitn(2, '=').collect();
             if vv.len() != 2 {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
@@ -557,7 +557,7 @@ impl Process {
                 let path = entry.path();
                 let fd_number = try!(
                     path.file_name()
-                        .ok_or(parse_error("Could not read /proc entry", &path))
+                        .ok_or_else(|| parse_error("Could not read /proc entry", &path))
                 );
                 if let Ok(fd_path) = read_link(&path) {
                     fds.push(Fd {
@@ -614,7 +614,7 @@ pub fn all() -> Result<Vec<Process>> {
         let path = try!(entry).path();
         let name = try!(
             path.file_name()
-                .ok_or(parse_error("Could not read /proc entry", &path))
+                .ok_or_else(|| parse_error("Could not read /proc entry", &path))
         );
         if let Ok(pid) = PID::from_str(&name.to_string_lossy()) {
             processes.push(try!(Process::new(pid)))

--- a/src/system.rs
+++ b/src/system.rs
@@ -57,15 +57,15 @@ impl VirtualMemory {
         let used = total - free - cached - buffers;
 
         VirtualMemory {
-            total: total,
-            available: available,
-            shared: shared,
-            free: free,
-            buffers: buffers,
-            cached: cached,
-            active: active,
-            inactive: inactive,
-            used: used,
+            total,
+            available,
+            shared,
+            free,
+            buffers,
+            cached,
+            active,
+            inactive,
+            used,
             percent: (used as f32 / total as f32) * 100.0,
         }
     }
@@ -97,12 +97,12 @@ impl SwapMemory {
         let percent = (used as f32 / total as f32) * 100.0;
 
         SwapMemory {
-            total: total,
-            used: used,
-            free: free,
-            percent: percent,
-            sin: sin,
-            sout: sout,
+            total,
+            used,
+            free,
+            percent,
+            sin,
+            sout,
         }
     }
 }
@@ -258,21 +258,29 @@ pub fn virtual_memory() -> Result<VirtualMemory> {
     let data = read_file(Path::new("/proc/meminfo"))?;
     let mem_info = make_map(&data)?;
 
-    let total = *mem_info.get("MemTotal:").ok_or(not_found("MemTotal"))?;
-    let free = *mem_info.get("MemFree:").ok_or(not_found("MemFree"))?;
-    let buffers = *mem_info.get("Buffers:").ok_or(not_found("Buffers"))?;
-    let cached = *mem_info.get("Cached:").ok_or(not_found("Cached"))?;
-    let active = *mem_info.get("Active:").ok_or(not_found("Active"))?;
-    let inactive = *mem_info.get("Inactive:").ok_or(not_found("Inactive"))?;
+    let total = *mem_info
+        .get("MemTotal:")
+        .ok_or_else(|| not_found("MemTotal"))?;
+    let free = *mem_info
+        .get("MemFree:")
+        .ok_or_else(|| not_found("MemFree"))?;
+    let buffers = *mem_info
+        .get("Buffers:")
+        .ok_or_else(|| not_found("Buffers"))?;
+    let cached = *mem_info.get("Cached:").ok_or_else(|| not_found("Cached"))?;
+    let active = *mem_info.get("Active:").ok_or_else(|| not_found("Active"))?;
+    let inactive = *mem_info
+        .get("Inactive:")
+        .ok_or_else(|| not_found("Inactive"))?;
 
     // MemAvailable was introduced in kernel 3.14. The original psutil computes it if it's not
     // found, but since 3.14 has already reached EOL, let's assume that it's there.
     let available = *mem_info
         .get("MemAvailable:")
-        .ok_or(not_found("MemAvailable"))?;
+        .ok_or_else(|| not_found("MemAvailable"))?;
 
     // Shmem was introduced in 2.6.19
-    let shared = *mem_info.get("Shmem:").ok_or(not_found("Shmem"))?;
+    let shared = *mem_info.get("Shmem:").ok_or_else(|| not_found("Shmem"))?;
 
     Ok(VirtualMemory::new(
         total, available, shared, free, buffers, cached, active, inactive,
@@ -289,10 +297,18 @@ pub fn swap_memory() -> Result<SwapMemory> {
     let vmstat = read_file(Path::new("/proc/vmstat"))?;
     let vmstat_info = make_map(&vmstat)?;
 
-    let total = *swap_info.get("SwapTotal:").ok_or(not_found("SwapTotal"))?;
-    let free = *swap_info.get("SwapFree:").ok_or(not_found("SwapFree"))?;
-    let sin = *vmstat_info.get("pswpin").ok_or(not_found("pswpin"))?;
-    let sout = *vmstat_info.get("pswpout").ok_or(not_found("pswpout"))?;
+    let total = *swap_info
+        .get("SwapTotal:")
+        .ok_or_else(|| not_found("SwapTotal"))?;
+    let free = *swap_info
+        .get("SwapFree:")
+        .ok_or_else(|| not_found("SwapFree"))?;
+    let sin = *vmstat_info
+        .get("pswpin")
+        .ok_or_else(|| not_found("pswpin"))?;
+    let sout = *vmstat_info
+        .get("pswpout")
+        .ok_or_else(|| not_found("pswpout"))?;
 
     Ok(SwapMemory::new(total, free, sin, sout))
 }
@@ -329,7 +345,7 @@ fn make_map(data: &str) -> Result<HashMap<&str, u64>> {
         };
 
         if let Some(multiplier) = get_multiplier(&mut fields) {
-            value = value * multiplier;
+            value *= multiplier;
         }
 
         map.insert(key, value);

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,10 +1,10 @@
 //! Read information about the operating system from `/proc`.
 
-use std::str::FromStr;
-use std::path::Path;
 use std::collections::HashMap;
+use std::path::Path;
+use std::str::FromStr;
 
-use std::io::{Result, ErrorKind, Error};
+use std::io::{Error, ErrorKind, Result};
 
 use PID;
 
@@ -267,22 +267,15 @@ pub fn virtual_memory() -> Result<VirtualMemory> {
 
     // MemAvailable was introduced in kernel 3.14. The original psutil computes it if it's not
     // found, but since 3.14 has already reached EOL, let's assume that it's there.
-    let available = *mem_info.get("MemAvailable:").ok_or(
-        not_found("MemAvailable"),
-    )?;
+    let available = *mem_info
+        .get("MemAvailable:")
+        .ok_or(not_found("MemAvailable"))?;
 
     // Shmem was introduced in 2.6.19
     let shared = *mem_info.get("Shmem:").ok_or(not_found("Shmem"))?;
 
     Ok(VirtualMemory::new(
-        total,
-        available,
-        shared,
-        free,
-        buffers,
-        cached,
-        active,
-        inactive,
+        total, available, shared, free, buffers, cached, active, inactive,
     ))
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,8 +18,10 @@ macro_rules! try_parse {
     ($field:expr, $from_str:path) => {
         try!(match $from_str($field) {
             Ok(result) => Ok(result),
-            Err(_) => Err(Error::new(ErrorKind::InvalidInput,
-                format!("Could not parse {:?}", $field)))
+            Err(_) => Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Could not parse {:?}", $field)
+            )),
         })
     };
 }

--- a/tests/pidfile.rs
+++ b/tests/pidfile.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use tempdir::TempDir;
 
-use psutil::pidfile::{read_pidfile,write_pidfile};
+use psutil::pidfile::{read_pidfile, write_pidfile};
 
 #[test]
 fn read_write_pidfile() {

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -12,8 +12,8 @@ fn process_alive() {
 #[test]
 fn process_cpu() {
     let process = get_process();
-    assert!(process.utime  >= 0.0);
-    assert!(process.stime  >= 0.0);
+    assert!(process.utime >= 0.0);
+    assert!(process.stime >= 0.0);
     assert!(process.cutime >= 0.0);
     assert!(process.cstime >= 0.0);
 }


### PR DESCRIPTION
Folowing PR #31, this is some change suggested by clippy. 
Here are the two warnings that I could not correct. The first is link to the multiple call of try_parse! macro. I did not correct the second because the new() function is public.

```
warning: the function has a cyclomatic complexity of 58
   --> src/process.rs:386:5
    |
386 | /     fn new_internal(stat: &str, file_uid: UID, file_gid: GID, path: &PathBuf) -> Result<Process> {
387 | |         // Read the PID and comm fields separately, as the comm field is delimited by brackets and
388 | |         // could contain spaces.
389 | |         let (pid_, rest) = match stat.find('(') {
...   |
476 | |         })
477 | |     }
    | |_____^
    |
    = note: #[warn(cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cyclomatic_complexity

warning: this function has too many arguments (8/7)
  --> src/system.rs:47:5
   |
47 | /     pub fn new(
48 | |         total: u64,
49 | |         available: u64,
50 | |         shared: u64,
...  |
70 | |         }
71 | |     }
   | |_____^
   |
   = note: #[warn(too_many_arguments)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#too_many_arguments
```