### PR TITLE
Use read_exact to speed up file I/O

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility methods, mostly for dealing with IO.
 
 use std::fs;
-use std::io::{Read, Result};
+use std::io::{Read, Result, Error, ErrorKind};
 use std::path::Path;
 
 pub fn read_file(path: &Path) -> Result<String> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,10 +5,11 @@ use std::io::{Read, Result};
 use std::path::Path;
 
 pub fn read_file(path: &Path) -> Result<String> {
-    let mut buffer = String::new();
-    let mut file = try!(File::open(path));
-    try!(file.read_to_string(&mut buffer));
-    Ok(buffer)
+    let metadata = try!(fs::metadata(path));
+    let mut buffer = Vec::with_capacity(metadata.len() as usize);
+    let mut file = try!(fs::File::open(path));
+    try!(file.read_exact(&mut buffer));
+    Ok(String::from_utf8(buffer))
 }
 
 macro_rules! try_parse {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utility methods, mostly for dealing with IO.
 
-use std::fs::File;
+use std::fs;
 use std::io::{Read, Result};
 use std::path::Path;
 
@@ -9,7 +9,7 @@ pub fn read_file(path: &Path) -> Result<String> {
     let mut buffer = Vec::with_capacity(metadata.len() as usize);
     let mut file = try!(fs::File::open(path));
     try!(file.read_exact(&mut buffer));
-    Ok(String::from_utf8(buffer))
+    Ok(String::from_utf8(buffer).unwrap())
 }
 
 macro_rules! try_parse {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,11 @@ pub fn read_file(path: &Path) -> Result<String> {
     let mut buffer = Vec::with_capacity(metadata.len() as usize);
     let mut file = try!(fs::File::open(path));
     try!(file.read_exact(&mut buffer));
-    Ok(String::from_utf8(buffer).unwrap())
+    let metadata = try!(fs::metadata(path));
+    let mut buffer = Vec::with_capacity(metadata.len() as usize);
+    let mut file = try!(fs::File::open(path));
+    try!(file.read_exact(&mut buffer));
+    String::from_utf8(buffer).map_err(|err| Error::new(ErrorKind::Other, err.to_string()))
 }
 
 macro_rules! try_parse {


### PR DESCRIPTION
Even though kernel calls to get the metadata take time, it is still faster than having to re-allocate while reading to the end of the file. Being able to allocate only the size of the file makes reads 2-20x faster. (reading /proc/meminfo was about 2x faster, while reading /proc/stat was up to 20 times faster).

I tested this through the following program:

```
#![feature(test)]

extern crate test;

#[cfg(test)]
mod tests {
    use test::{Bencher};
    use std::fs;
    use std::io::{Read, Result};
    use std::path::Path;

    fn read_file(path: &Path) -> Result<String> {
        let mut buffer = String::new();
        let mut file = try!(fs::File::open(path));
        try!(file.read_to_string(&mut buffer));
        Ok(buffer)
    }

    fn read_file_faster(path: &Path) -> Result<String> {
        let metadata = try!(fs::metadata(path));
        let mut buffer = Vec::with_capacity(metadata.len() as usize);
        let mut file = try!(fs::File::open(path));
        try!(file.read_exact(&mut buffer));
        Ok(String::from_utf8(buffer).unwrap())
    }

    #[bench]
    fn read_faster(b: &mut Bencher) {
        b.iter(|| {
            read_file_faster(Path::new("f")).unwrap();
            }
        );
    }

    #[bench]
    fn read_normal(b: &mut Bencher) {
        b.iter(|| {
            read_file(Path::new("f")).unwrap();
            }
        );
    }
}
```

I also swapped the names of the benchmarks to make sure that nothing related to caching or things like that interfered with the results.

Sample output (testing reading `/proc/stat`:
```
running 2 tests
test tests::bench_read        ... bench:      51,036 ns/iter (+/- 1,861)
test tests::bench_read_faster ... bench:       3,280 ns/iter (+/- 1,403)
```

