### PR TITLE
bump lazy-static and tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 libc = ">= 0.1.4"
-lazy_static = "0.1"
+lazy_static = "1"
 
 [dev-dependencies]
-tempdir = ">= 0.3.5"
+tempfile = "3"

--- a/tests/pidfile.rs
+++ b/tests/pidfile.rs
@@ -1,17 +1,15 @@
 extern crate psutil;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::fs::File;
 use std::io::Write;
-
-use tempdir::TempDir;
 
 use psutil::pidfile::{read_pidfile, write_pidfile};
 
 #[test]
 fn read_write_pidfile() {
     // This will be removed automatically when dropped
-    let tempdir = TempDir::new("psutil-tests").unwrap();
+    let tempdir = tempfile::Builder::new().prefix("psutil-tests").tempdir().unwrap();
     let pidfile = tempdir.path().join("read_write_pidfile.pid");
 
     // Write the pidfile to the temporary directory
@@ -24,7 +22,7 @@ fn read_write_pidfile() {
 #[test]
 #[should_panic]
 fn read_invalid_pidfile() {
-    let tempdir = TempDir::new("psutil-tests").unwrap();
+    let tempdir = tempfile::Builder::new().prefix("psutil-tests").tempdir().unwrap();
     let pidfile = tempdir.path().join("read_invalid_pidfile.pid");
 
     write!(&mut File::create(&pidfile).unwrap(), "{}", "beans").unwrap();


### PR DESCRIPTION
I believe this old version of `lazy-static` has some pretty serious issues.

`tempdir` has been merged into `tempfile`.