### PR TITLE
fix u32/u64 mismatch, change deprecated trim_right to trim_end

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -386,9 +386,9 @@ pub fn disk_usage(path: &str) -> Result<DiskUsage> {
             "failed to use statvfs : statvfs return an error code".to_string(),
         ));
     }
-    let total = buf.f_blocks * buf.f_frsize;
-    let avail_to_root = buf.f_bfree * buf.f_frsize;
-    let free = buf.f_bavail * buf.f_frsize;
+    let total = buf.f_blocks as u64 * buf.f_frsize;
+    let avail_to_root = buf.f_bfree as u64 * buf.f_frsize;
+    let free = buf.f_bavail as u64 * buf.f_frsize;
     let used = total - avail_to_root;
     let total_user = used + free;
     let percent = if total_user > 0 {
@@ -396,8 +396,8 @@ pub fn disk_usage(path: &str) -> Result<DiskUsage> {
     } else {
         0.
     };
-    let disk_inodes_free = buf.f_ffree;
-    let disk_inodes_total = buf.f_files;
+    let disk_inodes_free = buf.f_ffree as u64;
+    let disk_inodes_total = buf.f_files as u64;
     let disk_inodes_used = if disk_inodes_total >= disk_inodes_free {
         disk_inodes_total - disk_inodes_free
     } else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -135,7 +135,7 @@ impl Memory {
     pub fn new(pid: PID) -> Result<Memory> {
         let path = procfs_path(pid, "statm");
         let statm = try!(read_file(&path));
-        let fields: Vec<&str> = statm.trim_right().split(' ').collect();
+        let fields: Vec<&str> = statm.trim_end().split(' ').collect();
 
         Ok(Memory {
             size: try!(Memory::parse_bytes(fields[0], &path)) * *PAGE_SIZE,
@@ -399,7 +399,7 @@ impl Process {
         let mut fields: Vec<&str> = Vec::new();
         fields.push(pid_);
         fields.push(&comm[2..comm.len() - 2]);
-        fields.extend(rest.trim_right().split(' '));
+        fields.extend(rest.trim_end().split(' '));
 
         // Check we haven't read more or less fields than expected.
         if fields.len() != 52 {


### PR DESCRIPTION
Hi,

This pull request fixes the module not building on the latest Rust stable. I was getting a bunch of the following types of errors:

```
error[E0308]: mismatched types
   --> src/disk.rs:389:32
    |
389 |     let total = buf.f_blocks * buf.f_frsize;
    |                                ^^^^^^^^^^^^ expected u32, found u64

error[E0277]: cannot multiply `u64` to `u32`
   --> src/disk.rs:389:30
    |
389 |     let total = buf.f_blocks * buf.f_frsize;
    |                              ^ no implementation for `u32 * u64`
    |
    = help: the trait `std::ops::Mul<u64>` is not implemented for `u32`

error[E0308]: mismatched types
   --> src/disk.rs:390:39
    |
390 |     let avail_to_root = buf.f_bfree * buf.f_frsize;
    |                                       ^^^^^^^^^^^^ expected u32, found u64
```

It looks like there was a change in some of the fields from u32 to u64 or vice-versa. I added some casts so that the build would not fail. Thanks!