### PR TITLE
Refactor

### DIFF
--- a/examples/disk_io_counters.rs
+++ b/examples/disk_io_counters.rs
@@ -32,22 +32,10 @@ fn main() {
             read_bytes:         {} Bytes/s
             write_bytes:        {} Bytes/s
             ",
-            (current_disk_io_counters
-                .get(&String::from("sda"))
-                .unwrap()
-                .read_bytes
-                - past_disk_io_counters
-                    .get(&String::from("sda"))
-                    .unwrap()
-                    .read_bytes),
-            (current_disk_io_counters
-                .get(&String::from("sda"))
-                .unwrap()
-                .write_bytes
-                - past_disk_io_counters
-                    .get(&String::from("sda"))
-                    .unwrap()
-                    .write_bytes),
+            (current_disk_io_counters[&String::from("sda")].read_bytes
+                - past_disk_io_counters[&String::from("sda")].read_bytes),
+            (current_disk_io_counters[&String::from("sda")].write_bytes
+                - past_disk_io_counters[&String::from("sda")].write_bytes),
         );
     }
 }

--- a/examples/ps.rs
+++ b/examples/ps.rs
@@ -16,7 +16,9 @@ fn main() {
             p.state.to_string(),
             p.utime,
             p.stime,
-            p.cmdline().unwrap().unwrap_or(format!("[{}]", p.comm))
+            p.cmdline()
+                .unwrap()
+                .unwrap_or_else(|| format!("[{}]", p.comm))
         );
     }
 }

--- a/src/pidfile.rs
+++ b/src/pidfile.rs
@@ -1,21 +1,25 @@
 //! Contains functions to read and write pidfiles.
 
-use std::fs::File;
+use std::fs::{self, File};
+use std::io::Write;
 use std::io::{Error, ErrorKind, Result};
-use std::io::{Read, Write};
 use std::path::Path;
 use std::str::FromStr;
 
 /// Writes the PID of the current process to a file.
-pub fn write_pidfile(path: &Path) -> Result<()> {
-    return write!(&mut File::create(path).unwrap(), "{}", super::getpid());
+pub fn write_pidfile<P>(path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    return write!(&mut File::create(path)?, "{}", super::getpid());
 }
 
 /// Reads a PID from a file.
-pub fn read_pidfile(path: &Path) -> Result<super::PID> {
-    let mut file = File::open(path)?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
+pub fn read_pidfile<P>(path: P) -> Result<super::PID>
+where
+    P: AsRef<Path>,
+{
+    let contents = fs::read_to_string(&path)?;
 
     match FromStr::from_str(&contents) {
         Ok(pid) => Ok(pid),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,12 +16,12 @@ macro_rules! try_parse {
         try_parse!($field, FromStr::from_str)
     };
     ($field:expr, $from_str:path) => {
-        try!(match $from_str($field) {
+        match $from_str($field) {
             Ok(result) => Ok(result),
             Err(_) => Err(Error::new(
                 ErrorKind::InvalidInput,
-                format!("Could not parse {:?}", $field)
+                format!("Could not parse {:?}", $field),
             )),
-        })
+        }?
     };
 }


### PR DESCRIPTION
- replaced 'try!' with '?'
- changed 'Path' arguments to 'AsRef<Path>' for more robustness
- fixed clippy lints
- fixed spelling: espected -> expected
- fixed an unecessary unwrap

edit: Changing Path to AsRef<Path> doesn't cause any breaking changes, it just allows for Paths, PathBufs, and &strs to be passed in and it seems to be the recommended way to accept paths as function paramters in rust