### PR TITLE
Add benchmark test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ lazy_static = "1"
 
 [dev-dependencies]
 tempfile = "3"
+bencher = "*"
+
+[[bench]]
+name = "benchmarking"
+harness = false

--- a/benches/benchmarking.rs
+++ b/benches/benchmarking.rs
@@ -1,0 +1,39 @@
+#[macro_use]
+extern crate bencher;
+
+use bencher::Bencher;
+
+fn uptime_bench(b: &mut Bencher) {
+    b.iter(|| psutil::system::uptime());
+}
+
+fn mem_bench(b: &mut Bencher) {
+    b.iter(|| psutil::system::virtual_memory().unwrap());
+}
+
+fn swap_bench(b: &mut Bencher) {
+    b.iter(|| psutil::system::swap_memory().unwrap());
+}
+
+fn loadavg_bench(b: &mut Bencher) {
+    b.iter(|| psutil::system::loadavg().unwrap());
+}
+
+fn cpucount_logical_bench(b: &mut Bencher) {
+    b.iter(|| psutil::cpu::cpu_count(true).unwrap());
+}
+
+fn cpucount_physical_bench(b: &mut Bencher) {
+    b.iter(|| psutil::cpu::cpu_count(false).unwrap());
+}
+
+benchmark_group!(
+    benches,
+    uptime_bench,
+    mem_bench,
+    swap_bench,
+    loadavg_bench,
+    cpucount_logical_bench,
+    cpucount_physical_bench,
+);
+benchmark_main!(benches);


### PR DESCRIPTION
I wanted to see what functions were fast or slow and try to improve them, so I added a benchmarking suite.

Output of `cargo bench` on my system is:

```
     Running target/release/deps/benchmarking-849b7c8864a925fd

running 6 tests
test cpucount_logical_bench  ... bench:      56,006 ns/iter (+/- 7,693)
test cpucount_physical_bench ... bench:      55,968 ns/iter (+/- 6,038)
test loadavg_bench           ... bench:       7,132 ns/iter (+/- 3,441)
test mem_bench               ... bench:      33,815 ns/iter (+/- 17,506)
test swap_bench              ... bench:      96,744 ns/iter (+/- 19,702)
test uptime_bench            ... bench:       5,838 ns/iter (+/- 928)
```